### PR TITLE
Draw generated PNG as sprite

### DIFF
--- a/Forest.tscn
+++ b/Forest.tscn
@@ -1,19 +1,11 @@
-[gd_scene load_steps=4 format=2]
+[gd_scene load_steps=2 format=2]
 
 [ext_resource path="res://Forest.gdns" type="Script" id=1]
-[ext_resource path="res://plant_07.svg" type="Texture" id=3]
-
-[sub_resource type="ShaderMaterial" id=1]
 
 [node name="Forest" type="Node2D"]
 script = ExtResource( 1 )
 
-[node name="Sprite" type="Sprite" parent="."]
-material = SubResource( 1 )
-position = Vector2( 4, 12 )
-texture = ExtResource( 3 )
-
-[node name="Camera2D" type="Camera2D" parent="Sprite"]
-position = Vector2( 158.625, 42.0828 )
+[node name="Camera2D" type="Camera2D" parent="."]
+position = Vector2( 162.625, 54.0828 )
 current = true
 zoom = Vector2( 2.6, 2.6 )

--- a/gen/Cargo.toml
+++ b/gen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "forest_gen"
-version = "0.0.7"
+version = "0.0.8"
 authors = ["terkwood <38859656+Terkwood@users.noreply.github.com>"]
 edition = "2018"
 


### PR DESCRIPTION
Generates an SVG, converts to PNG, and immediately draws the data as a sprite -- without writing anything to disk.