### PR TITLE
Refactor lindenmayer crate

### DIFF
--- a/lindenmayer/Cargo.toml
+++ b/lindenmayer/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["terkwood <38859656+Terkwood@users.noreply.github.com>"]
 edition = "2018"
 name = "lindenmayer"
-version = "0.4.1"
+version = "0.5.0"
 
 [dependencies]
 expression = "0.3.4"

--- a/lindenmayer/src/lib.rs
+++ b/lindenmayer/src/lib.rs
@@ -1,6 +1,6 @@
-pub mod parametric;
-pub mod png;
-pub mod svg;
+mod parametric;
+mod png;
+mod svg;
 
 mod draw;
 mod lsys;
@@ -19,7 +19,34 @@ const RULE_X_1: &str = "F[+X][-X]FX";
 #[allow(unused)]
 const RULE_F_CLASSIC: &str = "FF-[-F+F+F]+[+F-F-F]";
 
-pub fn develop_system(start: char, rules: Vec<Rule>, iter: usize) -> (Vec<PSym<char, f32>>, usize) {
+pub struct TreeOptions {
+    pub axiom: char,
+    pub delta: f32,
+    pub rules: Vec<Rule>,
+    pub n: usize,
+    pub stroke_width: f32,
+    pub stroke_length: f32,
+}
+
+#[derive(Debug)]
+pub struct Size {
+    pub width: u32,
+    pub height: u32,
+}
+
+#[derive(Debug)]
+pub struct PngBytes {
+    pub bytes: Vec<u8>,
+    pub size: Size,
+}
+
+pub fn tree(opts: TreeOptions) -> PngBytes {
+    let svg_bytes = svg::draw_svg_utf8(opts);
+    let (bytes, size) = png::convert_svg_to_png_bytes(&svg_bytes);
+    PngBytes { bytes, size }
+}
+
+fn develop_system(start: char, rules: Vec<Rule>, iter: usize) -> (Vec<PSym<char, f32>>, usize) {
     let mut system = System::new();
     for r in rules {
         system.add_rule(r)
@@ -27,15 +54,12 @@ pub fn develop_system(start: char, rules: Vec<Rule>, iter: usize) -> (Vec<PSym<c
     system.develop(symstr(&start.to_string()), iter)
 }
 
-pub type Real = f32;
-pub type SymExpr = PSym<char, Expr<Real>>;
-pub type SymR = PSym<char, Real>;
+type Real = f32;
+type SymExpr = PSym<char, Expr<Real>>;
+type SymR = PSym<char, Real>;
 
 pub type Rule = PRule<char, SymExpr, SymR, Cond<Expr<Real>>>;
-pub type System = PSystem<Rule>;
-pub fn create_system() -> System {
-    System::new()
-}
+type System = PSystem<Rule>;
 
 pub fn symstr<S, R>(s: &str) -> Vec<S>
 where

--- a/lindenmayer/src/png.rs
+++ b/lindenmayer/src/png.rs
@@ -1,11 +1,6 @@
+use crate::Size;
 use tiny_skia::Pixmap;
 use usvg::FitTo;
-
-#[derive(Debug)]
-pub struct Size {
-    pub width: u32,
-    pub height: u32,
-}
 
 pub fn convert_svg_to_png_bytes(data: &[u8]) -> (Vec<u8>, Size) {
     let out = convert_svg_to_png(data);

--- a/lindenmayer/src/svg.rs
+++ b/lindenmayer/src/svg.rs
@@ -1,18 +1,9 @@
 use crate::draw::*;
-use crate::Rule;
+use crate::TreeOptions;
 
 const INIT_DIRECTION: f32 = 0.0;
 
-pub struct DrawOptions {
-    pub axiom: char,
-    pub delta: f32,
-    pub rules: Vec<Rule>,
-    pub n: usize,
-    pub stroke_width: f32,
-    pub stroke_length: f32,
-}
-
-pub fn draw_svg_utf8(draw_props: DrawOptions) -> Vec<u8> {
+pub fn draw_svg_utf8(draw_props: TreeOptions) -> Vec<u8> {
     let (after, _) = crate::develop_system(draw_props.axiom, draw_props.rules, draw_props.n);
 
     let mut v = vec![];


### PR DESCRIPTION
Move functions & defs around, rename the main function to `tree`, and restrict some things as private.  Updates `gen` crate accordingly