### PR TITLE
feat: Use white stroke in lindenmayer SVG draw

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,10 @@
 
 This release features the ability to add solid colors to the trees. (#49)
 
+- Use SVG stroke-color "white" in lindenmayer::draw (#52)
 - Update turtle dependency (#50)
 - Upgrade various dependencies (#51) 
-- Fix an unused var warning
+- Fix an unused var warning (commit 574c5a0)
 
 Subproject versions:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 This release features the ability to add solid colors to the trees. (#49)
 
 - Use SVG stroke-color "white" in lindenmayer::draw (#52)
+- Create a ProceduralSky in the main scene (#52)
 - Update turtle dependency (#50)
 - Upgrade various dependencies (#51) 
 - Fix an unused var warning (commit 574c5a0)

--- a/SpatialTree.gd
+++ b/SpatialTree.gd
@@ -29,6 +29,7 @@ func _make_opposite_faces(img: Image, resize_y_ratio: float, rot_y: float, trans
 	spatial_mat.albedo_color = Color.white
 	spatial_mat.albedo_texture = tex
 	spatial_mat.flags_transparent = true
+	spatial_mat.flags_disable_ambient_light = true
 	
 	var first_face = _make_mesh_instance(spatial_mat, resize_y_ratio, rot_y, translate_x)
 	add_child(first_face)

--- a/SpatialTree.gd
+++ b/SpatialTree.gd
@@ -11,9 +11,7 @@ export var image_cache_path: NodePath
 const TreeParams = preload("res://TreeParams.gd")
 
 func _ready():
-	var make_image_start_time = OS.get_ticks_msec()
 	var img = _cached_make_image()
-	print("make image took %d" % (OS.get_ticks_msec() - make_image_start_time))
 	
 	var translate_x = 0.5 - _guess_center_along_bottom(img)
 
@@ -27,14 +25,15 @@ func _make_opposite_faces(img: Image, resize_y_ratio: float, rot_y: float, trans
 	var tex = ImageTexture.new()
 	tex.create_from_image(img)
 	
-	var first_sm = SpatialMaterial.new()
-	first_sm.albedo_texture = tex
-	first_sm.flags_transparent = true
+	var spatial_mat = SpatialMaterial.new()
+	spatial_mat.albedo_color = Color.white
+	spatial_mat.albedo_texture = tex
+	spatial_mat.flags_transparent = true
 	
-	var first_face = _make_mesh_instance(first_sm, resize_y_ratio, rot_y, translate_x)
+	var first_face = _make_mesh_instance(spatial_mat, resize_y_ratio, rot_y, translate_x)
 	add_child(first_face)
 	
-	var second_face = _make_mesh_instance(first_sm, resize_y_ratio, rot_y, translate_x, true)
+	var second_face = _make_mesh_instance(spatial_mat, resize_y_ratio, rot_y, translate_x, true)
 	add_child(second_face)
 	
 func _make_mesh_instance(spatial_mat: SpatialMaterial, resize_y_ratio: float, rot_y: float, translate_x: float, flip_faces: bool = false) -> MeshInstance:
@@ -94,8 +93,6 @@ func _cached_make_image():
 		$NativeHelp.set("base/delta", delta)
 		$NativeHelp.set("base/stroke_width", stroke_width)
 		$NativeHelp.set("base/stroke_length", stroke_length)
-	
-		var make_image_start_time = OS.get_ticks_msec()
 	
 		var img_with_blank_space:Image = $NativeHelp.make_image()
 		if img_with_blank_space == null:

--- a/SpatialTree.gd
+++ b/SpatialTree.gd
@@ -29,7 +29,6 @@ func _make_opposite_faces(img: Image, resize_y_ratio: float, rot_y: float, trans
 	spatial_mat.albedo_color = Color.white
 	spatial_mat.albedo_texture = tex
 	spatial_mat.flags_transparent = true
-	spatial_mat.flags_disable_ambient_light = true
 	
 	var first_face = _make_mesh_instance(spatial_mat, resize_y_ratio, rot_y, translate_x)
 	add_child(first_face)

--- a/SpatialTree.gd
+++ b/SpatialTree.gd
@@ -26,7 +26,7 @@ func _make_opposite_faces(img: Image, resize_y_ratio: float, rot_y: float, trans
 	tex.create_from_image(img)
 	
 	var spatial_mat = SpatialMaterial.new()
-	spatial_mat.albedo_color = Color.white
+	spatial_mat.albedo_color = Color.darkolivegreen
 	spatial_mat.albedo_texture = tex
 	spatial_mat.flags_transparent = true
 	

--- a/SpatialTree.tscn
+++ b/SpatialTree.tscn
@@ -10,8 +10,8 @@ script = ExtResource( 2 )
 [node name="NativeHelp" type="Spatial" parent="."]
 script = ExtResource( 1 )
 base/delta = 22.5
-base/stroke_length = 10.0
-base/rules = "F:FF-[-F+F+F]+[+F-F-F]"
-base/axiom = "F"
 base/n = 4
 base/stroke_width = 4.0
+base/rules = "F:FF-[-F+F+F]+[+F-F-F]"
+base/axiom = "F"
+base/stroke_length = 10.0

--- a/SpatialTree.tscn
+++ b/SpatialTree.tscn
@@ -9,9 +9,9 @@ script = ExtResource( 2 )
 
 [node name="NativeHelp" type="Spatial" parent="."]
 script = ExtResource( 1 )
-base/delta = 22.5
 base/n = 4
-base/stroke_width = 4.0
-base/rules = "F:FF-[-F+F+F]+[+F-F-F]"
 base/axiom = "F"
+base/delta = 22.5
 base/stroke_length = 10.0
+base/rules = "F:FF-[-F+F+F]+[+F-F-F]"
+base/stroke_width = 4.0

--- a/TheWoods.tscn
+++ b/TheWoods.tscn
@@ -1,8 +1,13 @@
-[gd_scene load_steps=3 format=2]
+[gd_scene load_steps=4 format=2]
 
 [ext_resource path="res://TheWoods.gd" type="Script" id=1]
 
+[sub_resource type="ProceduralSky" id=2]
+
 [sub_resource type="Environment" id=1]
+background_mode = 2
+background_sky = SubResource( 2 )
+ambient_light_color = Color( 1, 1, 1, 1 )
 
 [node name="TheWoods" type="Spatial"]
 script = ExtResource( 1 )

--- a/lindenmayer/Cargo.toml
+++ b/lindenmayer/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["terkwood <38859656+Terkwood@users.noreply.github.com>"]
 edition = "2018"
 name = "lindenmayer"
-version = "0.5.2-b"
+version = "0.5.2"
 
 [dependencies]
 expression = "0.3.4"

--- a/lindenmayer/src/draw.rs
+++ b/lindenmayer/src/draw.rs
@@ -1,6 +1,6 @@
 use crate::parametric::ParametricSymbol;
 use std::io::Write;
-use turtle::{Canvas, SvgParams, SvgStrokeWidth, Turtle};
+use turtle::{Canvas, SvgParams, SvgStrokeColor, SvgStrokeWidth, Turtle};
 
 pub fn draw<W: Write>(
     symstr: &[crate::SymR],
@@ -36,7 +36,7 @@ pub fn draw<W: Write>(
         writer,
         SvgParams {
             stroke_width: SvgStrokeWidth(stroke_width),
-            ..Default::default()
+            stroke_color: SvgStrokeColor::from("white"),
         },
     )
     .unwrap();

--- a/lindenmayer/src/lib.rs
+++ b/lindenmayer/src/lib.rs
@@ -34,7 +34,7 @@ pub struct PngBytes {
 
 pub fn tree(opts: TreeOptions) -> PngBytes {
     let svg_bytes = svg::draw_svg_utf8(opts);
-    let (bytes, size) = png::convert_svg_to_png_bytes(&svg_bytes);
+    let (bytes, size) = png::render_pixmap_bytes(&svg_bytes);
     PngBytes { bytes, size }
 }
 

--- a/lindenmayer/src/lib.rs
+++ b/lindenmayer/src/lib.rs
@@ -26,6 +26,9 @@ pub struct Size {
     pub height: u32,
 }
 
+/// This is not an encoded PNG byte vec.
+/// These are the raw data from a tinyskia Pixmap,
+/// which apparently godot knows how to deal with!
 #[derive(Debug)]
 pub struct PngBytes {
     pub bytes: Vec<u8>,

--- a/lindenmayer/src/png.rs
+++ b/lindenmayer/src/png.rs
@@ -10,7 +10,7 @@ pub fn convert_svg_to_png_bytes(data: &[u8]) -> (Vec<u8>, Size) {
         height: out.height(),
     };
 
-    (out.data().to_vec(), size)
+    (out.encode_png().expect("encoded"), size)
 }
 
 fn convert_svg_to_png(data: &[u8]) -> Pixmap {

--- a/lindenmayer/src/png.rs
+++ b/lindenmayer/src/png.rs
@@ -22,3 +22,38 @@ fn convert_svg_to_png(data: &[u8]) -> Pixmap {
 
     pixmap
 }
+
+#[cfg(test)]
+mod tests {
+    use super::convert_svg_to_png_bytes;
+
+    #[test]
+    fn png_conversion_preserves_color() {
+        use turtle::{Canvas, SvgParams, SvgStrokeColor, SvgStrokeWidth, Turtle};
+        let mut t = Canvas::new();
+        let mut svg_out = vec![];
+        t.forward(100.0);
+        t.right(90.0);
+        t.forward(100.0);
+        t.pen_up();
+        t.forward(10.0);
+        t.pen_down();
+        t.right(90.0);
+        t.forward(100.0);
+        t.right(90.0);
+        t.forward(100.0);
+        t.save_svg(
+            &mut svg_out,
+            SvgParams {
+                stroke_color: SvgStrokeColor::from("white"),
+                stroke_width: SvgStrokeWidth(4.0),
+            },
+        )
+        .expect("write an svg square");
+
+        let (png_bytes, png_size) = convert_svg_to_png_bytes(&svg_out);
+        assert!(!png_bytes.is_empty());
+        assert!(png_size.width > 0);
+        assert!(png_size.height > 0);
+    }
+}

--- a/lindenmayer/src/png.rs
+++ b/lindenmayer/src/png.rs
@@ -25,6 +25,8 @@ fn convert_svg_to_png(data: &[u8]) -> Pixmap {
 
 #[cfg(test)]
 mod tests {
+    use std::io::Write;
+
     use super::convert_svg_to_png_bytes;
 
     #[test]
@@ -55,5 +57,8 @@ mod tests {
         assert!(!png_bytes.is_empty());
         assert!(png_size.width > 0);
         assert!(png_size.height > 0);
+
+        let mut png_out_file_hack = std::fs::File::create("pngtest.png").expect("png test file");
+        png_out_file_hack.write(&png_bytes).expect("png test write");
     }
 }

--- a/lindenmayer/src/png.rs
+++ b/lindenmayer/src/png.rs
@@ -27,6 +27,23 @@ fn render_pixmap(data: &[u8]) -> Pixmap {
 mod tests {
     use super::*;
 
+    #[test]
+    fn render_pixmap_bytes_preserves_color() {
+        let (png_bytes, png_size) = render_pixmap_bytes(&white_square_svg_bytes());
+        assert!(!png_bytes.is_empty());
+        assert!(png_size.width > 0);
+        assert!(png_size.height > 0);
+        let mut found_white = false;
+        let chunked_bytes = png_bytes.chunks(4);
+        for four_bytes in chunked_bytes {
+            if four_bytes == &[0, 0, 0, 0] {
+                found_white = true;
+                break;
+            }
+        }
+        assert!(found_white)
+    }
+
     fn white_square_svg_bytes() -> Vec<u8> {
         use turtle::{Canvas, SvgParams, SvgStrokeColor, SvgStrokeWidth, Turtle};
         let mut t = Canvas::new();
@@ -50,22 +67,5 @@ mod tests {
         )
         .expect("write an svg square");
         svg_out
-    }
-
-    #[test]
-    fn render_pixmap_bytes_preserves_color() {
-        let (png_bytes, png_size) = render_pixmap_bytes(&white_square_svg_bytes());
-        assert!(!png_bytes.is_empty());
-        assert!(png_size.width > 0);
-        assert!(png_size.height > 0);
-        let mut found_white = false;
-        let chunked_bytes = png_bytes.chunks(4);
-        for four_bytes in chunked_bytes {
-            if four_bytes == &[0, 0, 0, 0] {
-                found_white = true;
-                break;
-            }
-        }
-        assert!(found_white)
     }
 }

--- a/lindenmayer/src/png.rs
+++ b/lindenmayer/src/png.rs
@@ -1,5 +1,5 @@
 use crate::Size;
-use tiny_skia::Pixmap;
+use tiny_skia::{Color, Pixmap};
 use usvg::FitTo;
 
 pub fn convert_svg_to_png_bytes(data: &[u8]) -> (Vec<u8>, Size) {


### PR DESCRIPTION
lindenmayer: Allows the color of the SVG stroke to be specified, and adds a test.  Renames methods to indicate that the output of the raster conversion is a basic Pixmap, not an encoded PNG data structure.

godot project: Sets a color for each spatial material. Adds a ProceduralSky with some light to the main scene, so that we can see the color.  

Advances #49.
