### PR TITLE
feat: tree stamp 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
-# next: v0.7.1
+# next: v0.8.0
 
+- feat: tree stamp (#56)
 - refactor: auto load image cache (#57)
-- Pull out sample tree params into an `Object` (#55)
+- refactor: sample tree params into an `Object` (#55)
 
 # v0.7.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # next: v0.8.0
 
-- feat: tree stamp (#56)
+- feat: tree stamp (#54, #56)
 - refactor: auto load image cache (#57)
 - refactor: sample tree params into an `Object` (#55)
 

--- a/StampedScene.gd
+++ b/StampedScene.gd
@@ -1,0 +1,6 @@
+extends Spatial
+
+const Stamp = preload("res://stamp.gd")
+
+func _ready():
+	printerr("write me")

--- a/StampedScene.gd
+++ b/StampedScene.gd
@@ -6,13 +6,6 @@ onready var _samples = preload("res://SampleParams.gd").new().make_all()
 const Stamp = preload("res://stamp.gd")
 
 func _ready():
-	# let's stamp something in a few places
-	# stamp some pines,
-	# stamp some oaks
-	
-	# stamp at different densities and brush sizes
-	# do all of this manually, don't try to figure
-	# out the stamp placement on the first pass
 	var stamp = Stamp.new()
 	stamp.apply(Vector3(10.0,0.0,10.0), _samples[0], self)
 	stamp.apply(Vector3(-10.0,0.0,-10.0), _samples[1], self)

--- a/StampedScene.gd
+++ b/StampedScene.gd
@@ -4,3 +4,10 @@ const Stamp = preload("res://stamp.gd")
 
 func _ready():
 	printerr("write me")
+	# let's stamp something in a few places
+	# stamp some pines,
+	# stamp some oaks
+	
+	# stamp at different densities and brush sizes
+	# do all of this manually, don't try to figure
+	# out the stamp placement on the first pass

--- a/StampedScene.gd
+++ b/StampedScene.gd
@@ -1,9 +1,11 @@
 extends Spatial
 
+const TreeParams = preload("res://TreeParams.gd")
+
+onready var _samples = preload("res://SampleParams.gd").new().make_all()
 const Stamp = preload("res://stamp.gd")
 
 func _ready():
-	printerr("write me")
 	# let's stamp something in a few places
 	# stamp some pines,
 	# stamp some oaks
@@ -11,3 +13,14 @@ func _ready():
 	# stamp at different densities and brush sizes
 	# do all of this manually, don't try to figure
 	# out the stamp placement on the first pass
+	var stamp = Stamp.new()
+	stamp.apply(Vector3(10.0,0.0,10.0), _samples[0], self)
+	stamp.apply(Vector3(-10.0,0.0,-10.0), _samples[1], self)
+	
+	var smaller_stamp = Stamp.new()
+	smaller_stamp.brush_size = 4
+	smaller_stamp.apply(Vector3(5.0, 0, -7.5), _samples[2], self)
+	
+	var denser_stamp = Stamp.new()
+	denser_stamp.density = 3
+	denser_stamp.apply(Vector3(-10.0, 0, 7.5), _samples[3], self)

--- a/StampedScene.tscn
+++ b/StampedScene.tscn
@@ -16,3 +16,4 @@ environment = SubResource( 2 )
 
 [node name="Camera" type="Camera" parent="."]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.561355, 1.25012 )
+current = true

--- a/StampedScene.tscn
+++ b/StampedScene.tscn
@@ -1,6 +1,6 @@
 [gd_scene load_steps=4 format=2]
 
-[ext_resource path="res://TheWoods.gd" type="Script" id=1]
+[ext_resource path="res://StampedScene.gd" type="Script" id=1]
 
 [sub_resource type="ProceduralSky" id=1]
 
@@ -8,13 +8,11 @@
 background_mode = 2
 background_sky = SubResource( 1 )
 
-[node name="TheWoods" type="Spatial"]
+[node name="StampedScene" type="Spatial"]
 script = ExtResource( 1 )
-
-[node name="Camera" type="Camera" parent="."]
-transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 16.574, 2, 38.087 )
-current = true
-fov = 90.8
 
 [node name="WorldEnvironment" type="WorldEnvironment" parent="."]
 environment = SubResource( 2 )
+
+[node name="Camera" type="Camera" parent="."]
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.561355, 1.25012 )

--- a/StampedScene.tscn
+++ b/StampedScene.tscn
@@ -15,5 +15,5 @@ script = ExtResource( 1 )
 environment = SubResource( 2 )
 
 [node name="Camera" type="Camera" parent="."]
-transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.561355, 1.25012 )
+transform = Transform( 1, 0, 0, 0, 0.93089, 0.365299, 0, -0.365299, 0.93089, 0.130265, 5.25541, 5.18292 )
 current = true

--- a/project.godot
+++ b/project.godot
@@ -22,6 +22,7 @@ config/icon="res://icon.png"
 [autoload]
 
 ImageCache="*res://ImageCache.gd"
+RandomizeOnce="*res://randomize_once.gd"
 
 [display]
 

--- a/randomize_once.gd
+++ b/randomize_once.gd
@@ -1,0 +1,4 @@
+extends Node
+
+func _ready():
+	randomize()

--- a/stamp.gd
+++ b/stamp.gd
@@ -1,0 +1,2 @@
+extends Object
+

--- a/stamp.gd
+++ b/stamp.gd
@@ -15,3 +15,7 @@ func stamp(pos: Vector3, _owner: Node):
 func _compute_transforms(pos: Vector3) -> Array:
 	printerr("write me")
 	return []
+
+func _random_point_in_circle() -> Vector3:
+	printerr("write me")
+	return Vector3()

--- a/stamp.gd
+++ b/stamp.gd
@@ -1,6 +1,6 @@
 extends Object
 
-export var brush_size: float = 100.0
+export var brush_size: float = 10.0
 export var density: float = 1.0
 
 func stamp(pos: Vector3, _owner: Node):
@@ -13,6 +13,7 @@ func stamp(pos: Vector3, _owner: Node):
 # compute a bunch of transforms given a position, brush size,
 # and density
 func _compute_transforms(pos: Vector3) -> Array:
+	var how_many = int(brush_size / density)
 	printerr("write me")
 	return []
 

--- a/stamp.gd
+++ b/stamp.gd
@@ -16,7 +16,7 @@ func _compute_transforms(pos: Vector3) -> Array:
 	printerr("write me")
 	return []
 
-func _rant_point_in_circle(radius: float) -> Vector3:
+func _rand_point_in_circle(radius: float) -> Vector3:
 	var x_sign = _rand_sign()
 	var z_sign = _rand_sign()
 	

--- a/stamp.gd
+++ b/stamp.gd
@@ -14,8 +14,10 @@ func stamp(pos: Vector3, _owner: Node):
 # and density
 func _compute_transforms(pos: Vector3) -> Array:
 	var how_many = int(brush_size / density)
-	printerr("write me")
-	return []
+	var out = []
+	for _b in how_many:
+		out.push_front(_rand_point_in_circle(brush_size / 2.0))
+	return out
 
 func _rand_point_in_circle(radius: float) -> Vector3:
 	var x_sign = _rand_sign()

--- a/stamp.gd
+++ b/stamp.gd
@@ -3,6 +3,9 @@ extends Object
 export var brush_size: float = 10.0
 export var density: float = 1.0
 
+const SpatialTree = preload("res://SpatialTree.gd")
+const TreeParams = preload("res://TreeParams.gd")
+
 func stamp(pos: Vector3, _owner: Node):
 	var transforms = _compute_transforms(pos)
 	for t in transforms:

--- a/stamp.gd
+++ b/stamp.gd
@@ -1,2 +1,9 @@
 extends Object
 
+export var brush_size: float = 100.0
+export var density: float = 1.0
+
+func stamp(_owner: Node):
+	return ERR_HELP
+	
+	

--- a/stamp.gd
+++ b/stamp.gd
@@ -2,6 +2,7 @@ extends Object
 
 export var brush_size: float = 10.0
 export var density: float = 1.0
+export var image_cache_path: NodePath = NodePath("/root/ImageCache") # autoload
 
 const SpatialTree = preload("res://SpatialTree.gd")
 const TreeParams = preload("res://TreeParams.gd")

--- a/stamp.gd
+++ b/stamp.gd
@@ -16,6 +16,14 @@ func _compute_transforms(pos: Vector3) -> Array:
 	printerr("write me")
 	return []
 
-func _random_point_in_circle() -> Vector3:
-	printerr("write me")
-	return Vector3()
+func _rant_point_in_circle(radius: float) -> Vector3:
+	var x_sign = _rand_sign()
+	var z_sign = _rand_sign()
+	
+	var x = x_sign * randf() * radius
+	var z = z_sign * randf() * radius
+	
+	return Vector3(x,0,z)
+
+func _rand_sign() -> float:
+	return -1.0 if randi()%2 == 0 else 1.0

--- a/stamp.gd
+++ b/stamp.gd
@@ -7,12 +7,20 @@ export var image_cache_path: NodePath = NodePath("/root/ImageCache") # autoload
 const SpatialTree = preload("res://SpatialTree.gd")
 const TreeParams = preload("res://TreeParams.gd")
 
-func stamp(pos: Vector3, tree_params: TreeParams, _owner: Node):
+func stamp(pos: Vector3, tree_params: TreeParams, owner: Node):
 	var transforms = _compute_transforms(pos)
 	for t in transforms:
-		printerr("write me")
-	return ERR_HELP
-	
+		var tree = SpatialTree.instance()
+		tree.image_cache_path = image_cache_path
+		tree.n = tree_params.n
+		tree.rules = tree_params.rules
+		tree.axiom = tree_params.axiom
+		tree.delta = tree_params.delta
+		tree.stroke_length = tree_params.stroke_length
+		tree.stroke_width = tree_params.stroke_width
+		tree.translate(t)
+		tree.rotate_y(deg2rad(randf() * 360))
+		owner.add_child(tree)
 	
 # compute a bunch of transforms given a position, brush size,
 # and density

--- a/stamp.gd
+++ b/stamp.gd
@@ -4,10 +4,10 @@ export var brush_size: float = 10.0
 export var density: float = 1.0
 export var image_cache_path: NodePath = NodePath("/root/ImageCache") # autoload
 
-const SpatialTree = preload("res://SpatialTree.gd")
+const SpatialTree = preload("res://SpatialTree.tscn")
 const TreeParams = preload("res://TreeParams.gd")
 
-func stamp(pos: Vector3, tree_params: TreeParams, owner: Node):
+func apply(pos: Vector3, tree_params: TreeParams, owner: Node):
 	var transforms = _compute_transforms(pos)
 	for t in transforms:
 		var tree = SpatialTree.instance()

--- a/stamp.gd
+++ b/stamp.gd
@@ -3,7 +3,15 @@ extends Object
 export var brush_size: float = 100.0
 export var density: float = 1.0
 
-func stamp(_owner: Node):
+func stamp(pos: Vector3, _owner: Node):
+	var transforms = _compute_transforms(pos)
+	for t in transforms:
+		printerr("write me")
 	return ERR_HELP
 	
 	
+# compute a bunch of transforms given a position, brush size,
+# and density
+func _compute_transforms(pos: Vector3) -> Array:
+	printerr("write me")
+	return []

--- a/stamp.gd
+++ b/stamp.gd
@@ -6,7 +6,7 @@ export var density: float = 1.0
 const SpatialTree = preload("res://SpatialTree.gd")
 const TreeParams = preload("res://TreeParams.gd")
 
-func stamp(pos: Vector3, _owner: Node):
+func stamp(pos: Vector3, tree_params: TreeParams, _owner: Node):
 	var transforms = _compute_transforms(pos)
 	for t in transforms:
 		printerr("write me")


### PR DESCRIPTION
# tree stamp

Implements a tree stamp with `brush_size` and `density` settings.  Useful for stamping out areas with a single type of tree.

Resolves #54 

![Screenshot from 2021-02-10 06-48-42](https://user-images.githubusercontent.com/38859656/107506483-20734f80-6b6c-11eb-95dc-bcefa3d34544.png)

## Plan

- [x] write basic stamp
- [x] do not write automated stamping of an area
- [x] manually make a scene that tapers from (e.g.) 100% pine to 100% oak